### PR TITLE
Add Azure plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -10,6 +10,14 @@
   },
   "plugins": [
     {
+      "name": "azure",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/microsoft/GitHub-Copilot-for-Azure/tree/main/claude"
+      },
+      "description": "Azure plugin for GitHub Copilot."
+    },
+    {
       "name": "workiq",
       "source": "plugins/workiq",
       "description": "WorkIQ plugin for GitHub Copilot.",


### PR DESCRIPTION
Add the Azure plugin to the marketplace.

We may be getting ahead of ourselves but the Azure SDK team is very excited about the official GitHub Copilot plugins collection. We've started work on a Claude plugin, consisting of the [Azure MCP server](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/README.md) and related agents and skills, and we're hoping we can re-use it in GitHub Copilot.

I realize this PR is probably not ready to go as-is, but we're hoping to get a conversation going. Thank you!