### PR TITLE
docs: add README files for workiq and spark plugins

### DIFF
--- a/plugins/spark/README.md
+++ b/plugins/spark/README.md
@@ -1,0 +1,89 @@
+# Spark Plugin for GitHub Copilot
+
+Spark provides opinionated, production-ready defaults for building web applications with GitHub Copilot. When you ask Copilot to build a web app, Spark supplies the technical foundation, design direction, and implementation patterns needed to go from idea to functional application quickly.
+
+## Overview
+
+| | |
+|---|---|
+| **Provider** | GitHub |
+| **Type** | Skill |
+| **Requires** | Node.js 18+, pnpm |
+
+## What Spark Can Do
+
+Spark gives Copilot the context to scaffold and build complete web applications from a single prompt:
+
+- **Stack selection:** Chooses the right technology variation based on your application's type and complexity
+- **Project scaffolding:** Provides step-by-step setup commands to initialize a working project
+- **Design guidance:** Supplies typography pairings, OKLCH color palettes, and layout patterns
+- **Implementation patterns:** Covers routing, data fetching, form handling, and state management
+- **Reference documentation:** Includes detailed design system, performance, and component pattern references used during generation
+
+## Skills
+
+### `spark-app-template`
+
+Activates when you want to build a new web application. Provides stack selection, project scaffolding, design guidance, and implementation patterns tailored to your use case.
+
+**Trigger examples:**
+
+- "Build me a web app for..."
+- "Create a dashboard that..."
+- "What stack should I use?"
+- "Start a new React project"
+
+## Tech Stack
+
+All Spark applications share a common foundation:
+
+| Category | Technology |
+|----------|------------|
+| Build tool | Vite |
+| Framework | React 19+ |
+| Language | TypeScript |
+| Package manager | pnpm |
+| Routing | TanStack Router (file-based, type-safe) |
+| Data fetching | TanStack Query |
+| Styling | Tailwind CSS v4+ |
+| Component library | shadcn/ui (New York style) |
+| Forms | react-hook-form + Zod |
+| Icons | Lucide React |
+| Animation | Motion |
+| Linting | Biome |
+
+## Stack Variations
+
+Spark selects a stack variation based on your application's complexity:
+
+| Variation | Use For | Additional Packages |
+|-----------|---------|---------------------|
+| **Default Web App** | General tools, utilities, simple CRUD apps, prototypes | None (base stack only) |
+| **Data Dashboard** | Analytics panels, admin interfaces, reporting tools | Recharts, date-fns |
+| **Content Showcase** | Marketing sites, portfolios, blogs, documentation | marked, dompurify |
+| **Complex Application** | SaaS platforms, enterprise tools, multi-view apps | Zustand, date-fns |
+
+## Design Principles
+
+Spark enforces a set of design standards across all generated applications:
+
+- **OKLCH color format** -- All color values use OKLCH for perceptual uniformity and wide-gamut support
+- **Distinctive typography** -- Common overused fonts (Inter, Roboto, Arial) are avoided in favor of considered pairings
+- **Single theme by default** -- Dark mode is opt-in, not the default
+- **Core Web Vitals targets** -- INP < 200ms, LCP < 2.5s, CLS < 0.1
+- **WCAG AA contrast** -- 4.5:1 for normal text, 3:1 for large text
+
+## Reference Documentation
+
+Spark includes detailed reference material used during code generation:
+
+| File | Contents |
+|------|----------|
+| `skills/spark-app-template/references/design-system.md` | Design philosophy, spatial composition, backgrounds, micro-interactions |
+| `skills/spark-app-template/references/typography-pairings.md` | Distinctive font combinations with personality guidance |
+| `skills/spark-app-template/references/color-palettes.md` | Pre-curated OKLCH palettes with WCAG validation |
+| `skills/spark-app-template/references/component-patterns.md` | Common shadcn/ui compositions and usage patterns |
+| `skills/spark-app-template/references/performance-checklist.md` | Core Web Vitals optimization and React Compiler setup |
+| `skills/spark-app-template/references/prd-template.md` | Simplified planning framework for new apps |
+| `skills/spark-app-template/references/radix-migration-guide.md` | Migration path from Radix UI to Base UI or React Aria |
+

--- a/plugins/workiq/README.md
+++ b/plugins/workiq/README.md
@@ -1,0 +1,73 @@
+# WorkIQ Plugin for GitHub Copilot
+
+WorkIQ connects GitHub Copilot to Microsoft 365 Copilot, giving Copilot access to workplace intelligence grounded in your organization's data. Ask natural language questions about emails, meetings, documents, Teams messages, and people, and receive answers sourced directly from your Microsoft 365 environment.
+
+## Overview
+
+| | |
+|---|---|
+| **Provider** | Microsoft |
+| **Type** | MCP Server + Skill |
+| **Requires** | Microsoft 365 Copilot license |
+
+## What WorkIQ Can Do
+
+WorkIQ gives Copilot access to your organization's Microsoft 365 data through a single natural language interface:
+
+- **Emails:** Find messages, summarize threads, surface action items
+- **Meetings:** Retrieve decisions, summaries, and action items from calendar events
+- **Documents:** Locate files across OneDrive and SharePoint
+- **Teams messages:** Search conversations and channel discussions
+- **People:** Identify experts, understand roles, and discover who owns what
+
+## Skills
+
+### `workiq`
+
+Activates when you ask about anything that might exist in Microsoft 365. Example trigger phrases:
+
+- "What did [person] say about..."
+- "What are [person]'s priorities?"
+- "What was decided in yesterday's meeting?"
+- "Find emails from [person] about..."
+- "Who is working on...?"
+- "What's the status of...?"
+
+## MCP Server
+
+WorkIQ uses the `@microsoft/workiq` MCP server, launched automatically via `npx`:
+
+```json
+{
+  "mcpServers": {
+    "workiq": {
+      "command": "npx",
+      "args": ["-y", "@microsoft/workiq@latest", "mcp"],
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+### Tool Reference
+
+| Tool | Parameter | Type | Description |
+|------|-----------|------|-------------|
+| `ask_work_iq` | `question` | `string` (required) | A natural language question to ask Microsoft 365 Copilot |
+
+**Example:**
+
+```json
+{
+  "question": "What are the latest top of mind items from my manager?"
+}
+```
+
+## Authentication
+
+Authentication is handled automatically using the connected user's Microsoft 365 credentials. No additional configuration is required.
+
+## Requirements
+
+- A Microsoft 365 Copilot license associated with the authenticated user account
+- Node.js (for `npx` to run the MCP server)


### PR DESCRIPTION
## What

Adds `README.md` files for the `workiq` and `spark` plugins.

## Why

Clicking "Open README" in the GitHub Copilot extensions marketplace currently returns a 404, as neither plugin directory contained a README.

This is seen in the images below:

<img width="406" height="228" alt="image" src="https://github.com/user-attachments/assets/cfd1e0d5-891d-422a-9c95-d6c40083cd7b" />

<br><br>
And after clicking the "Open README"
<br><br>

<img width="1895" height="327" alt="image" src="https://github.com/user-attachments/assets/567b4499-d0a7-4398-98eb-6a38ea614a6c" />

## Changes

- `plugins/workiq/README.md` -- documents the MCP server, `ask_work_iq` tool
  reference, supported data sources, authentication, and requirements
- `plugins/spark/README.md` -- documents the skill, tech stack, stack
  variations, design principles, and reference documentation index

Closes #18 