### PR TITLE
Fix marketplace source paths to use relative ./ prefix

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "workiq",
-      "source": "plugins/workiq",
+      "source": "./plugins/workiq",
       "description": "WorkIQ plugin for GitHub Copilot.",
       "version": "1.0.0",
       "skills": [
@@ -20,7 +20,7 @@
     },
     {
       "name": "spark",
-      "source": "plugins/spark",
+      "source": "./plugins/spark",
       "description": "Spark plugin for GitHub Copilot.",
       "version": "1.0.0",
       "skills": [


### PR DESCRIPTION
## Summary

- The `source` field in `.github/plugin/marketplace.json` plugin entries was missing the `./` prefix (e.g. `"plugins/workiq"` instead of `"./plugins/workiq"`)
- This causes Claude Code's marketplace schema validation to reject the file with `Invalid input` errors on `plugins.0.source` and `plugins.1.source`
- Added the `./` prefix to both plugin source paths to match the expected format

## Test plan

- Run `claude /plugin marketplace add github/copilot-plugins` and verify it no longer fails with schema validation errors