### PR TITLE
Add PlanetScale plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -26,6 +26,15 @@
       "skills": [
         "./skills/spark"
       ]
+    },
+    {
+      "name": "planetscale",
+      "source": {
+        "source": "github",
+        "repo": "planetscale/vscode-agent-plugin"
+      },
+      "description": "PlanetScale database tools — MCP server for querying schemas, running SQL, and getting performance insights, plus expert skills for MySQL, PostgreSQL, Vitess, and Postgres sharding.",
+      "version": "1.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Add PlanetScale plugin

Adds the PlanetScale plugin as an external entry in `marketplace.json`, sourced from [`planetscale/vscode-agent-plugin`](https://github.com/planetscale/vscode-agent-plugin).

### What it provides

- **MCP Server**: Authenticated access to PlanetScale organizations, databases, branches, schema, and query performance Insights via the hosted PlanetScale MCP endpoint (`https://mcp.pscale.dev/mcp/planetscale`). No local setup required.
- **4 Database Skills**:
  - `mysql` — Schema design, indexing, query tuning, transactions, and operations for MySQL/InnoDB
  - `postgres` — Best practices, query optimization, MVCC, connection pooling, and PlanetScale-specific Postgres tooling
  - `vitess` — VSchema, sharding, vindexes, online DDL, and VReplication for PlanetScale Vitess databases
  - `neki` — Sharding readiness for PostgreSQL (PlanetScale's sharded Postgres)

### Source repository

https://github.com/planetscale/vscode-agent-plugin