### PR TITLE
Add READMEs for spark and workiq plugins

### DIFF
--- a/plugins/spark/README.md
+++ b/plugins/spark/README.md
@@ -1,0 +1,33 @@
+# Spark
+
+Comprehensive guidance for building modern web applications with opinionated defaults for tech stack, design system, and code standards.
+
+## What it does
+
+Spark helps you quickly bootstrap high-quality web applications by providing:
+
+- Pre-vetted technology stack choices with multiple complexity-based variations
+- An opinionated design philosophy and system
+- Step-by-step setup workflows
+- Design and performance optimization guidance
+
+## Skills
+
+### `spark-app-template`
+
+Activated when a user wants to create a new web application, dashboard, or interactive interface. Provides guidance on:
+
+- **Tech stack** — Vite, React 19+, TypeScript, Tailwind CSS v4+, shadcn/ui, TanStack Router & Query
+- **Design system** — Typography pairings, OKLCH color palettes, spatial composition, micro-interactions
+- **Stack variations** — Pre-configured stacks tailored to app complexity (default web app, content showcase, data dashboard, complex application)
+- **Performance** — Core Web Vitals targets, React Compiler setup, optimization checklists
+- **Component patterns** — Common shadcn compositions and usage patterns
+
+## Stack variations
+
+| Stack | Use case |
+| --- | --- |
+| **Default Web App** | General-purpose tools, utilities, simple CRUD, MVPs, prototypes |
+| **Content Showcase** | Marketing sites, portfolios, blogs, documentation |
+| **Data Dashboard** | Analytics dashboards, admin panels, BI tools, monitoring |
+| **Complex Application** | SaaS platforms, enterprise tools, multi-view apps |

--- a/plugins/workiq/README.md
+++ b/plugins/workiq/README.md
@@ -2,15 +2,21 @@
 
 Workplace intelligence plugin that connects AI agents to Microsoft 365 Copilot, providing access to organizational data from Outlook, Teams, SharePoint, OneDrive, and Calendar.
 
+Powered by the [`@microsoft/workiq`](https://github.com/microsoft/work-iq-mcp) MCP server.
+
+> ⚠️ **Public Preview:** Features and APIs may change.
+
 ## What it does
 
 WorkIQ grounds AI assistance in real workplace context by querying Microsoft 365 data sources. It enables agents to answer questions about:
 
-- **Emails & messages** — Find and summarize email threads and Teams conversations
-- **Meetings** — Retrieve decisions, action items, and context from calendar events
-- **Documents** — Locate specs, design docs, and files across SharePoint and OneDrive
-- **People** — Identify subject-matter experts, project owners, and organizational relationships
-- **Priorities** — Surface what colleagues are focused on, team goals, and project status
+| Data type | Example questions |
+| --- | --- |
+| **Emails** | "What did John say about the proposal?" |
+| **Meetings** | "What's on my calendar tomorrow?" |
+| **Documents** | "Find my recent PowerPoint presentations" |
+| **Teams** | "Summarize today's messages in the Engineering channel" |
+| **People** | "Who is working on Project Alpha?" |
 
 ## Skills
 
@@ -20,8 +26,15 @@ Activated when a user asks about workplace context — what someone said, meetin
 
 ## MCP server
 
-WorkIQ includes an MCP server configuration (`.mcp.json`) that runs the `@microsoft/workiq` package. Authentication is automatic using the connected user's existing Microsoft 365 credentials.
+WorkIQ includes an MCP server configuration (`.mcp.json`) that runs the [`@microsoft/workiq`](https://www.npmjs.com/package/@microsoft/workiq) package. Authentication is automatic using the connected user's existing Microsoft 365 credentials.
 
-## Requirements
+## Prerequisites
 
-- Microsoft 365 account with Copilot access
+- **Node.js 18+** — [Download from nodejs.org](https://nodejs.org/)
+- **Microsoft 365 account** with Copilot access
+
+## Admin consent
+
+To access Microsoft 365 tenant data, the WorkIQ MCP server needs permissions that require administrative rights on the tenant. On first access, a consent dialog appears. If you are not an administrator, contact your tenant administrator to grant access.
+
+For more information, see Microsoft's [User and Admin Consent Overview](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/user-admin-consent-overview).

--- a/plugins/workiq/README.md
+++ b/plugins/workiq/README.md
@@ -1,0 +1,27 @@
+# WorkIQ
+
+Workplace intelligence plugin that connects AI agents to Microsoft 365 Copilot, providing access to organizational data from Outlook, Teams, SharePoint, OneDrive, and Calendar.
+
+## What it does
+
+WorkIQ grounds AI assistance in real workplace context by querying Microsoft 365 data sources. It enables agents to answer questions about:
+
+- **Emails & messages** — Find and summarize email threads and Teams conversations
+- **Meetings** — Retrieve decisions, action items, and context from calendar events
+- **Documents** — Locate specs, design docs, and files across SharePoint and OneDrive
+- **People** — Identify subject-matter experts, project owners, and organizational relationships
+- **Priorities** — Surface what colleagues are focused on, team goals, and project status
+
+## Skills
+
+### `workiq`
+
+Activated when a user asks about workplace context — what someone said, meeting outcomes, document locations, team priorities, or organizational knowledge. Uses the `ask_work_iq` MCP tool to query Microsoft 365 Copilot with natural language questions.
+
+## MCP server
+
+WorkIQ includes an MCP server configuration (`.mcp.json`) that runs the `@microsoft/workiq` package. Authentication is automatic using the connected user's existing Microsoft 365 credentials.
+
+## Requirements
+
+- Microsoft 365 account with Copilot access


### PR DESCRIPTION
Each plugin in `plugins/` was missing a README. This adds one for each so contributors and users can quickly understand what a plugin does without digging through skill files.

**Spark** — Documents the web app scaffolding skill, its core tech stack (Vite, React 19+, Tailwind v4+, shadcn/ui, TanStack), and the four complexity-based stack variations (default, content showcase, data dashboard, complex application).

**WorkIQ** — Documents the Microsoft 365 Copilot integration, with example queries by data type (emails, meetings, documents, Teams, people), prerequisites (Node.js 18+, M365 Copilot access), and a note on tenant admin consent. Links to the upstream [`@microsoft/workiq`](https://github.com/microsoft/work-iq-mcp) package for further details.