### PR TITLE
Add Microsoft Skills for Fabric plugins to marketplace and update README

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -38,6 +38,89 @@
 
       ],
       "mcpServers": ".mcp.json"
+    },
+    {
+      "name": "fabric-skills",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/skills-for-fabric",
+        "path": "plugins/fabric-skills"
+      },
+      "description": "Complete bundle: all Microsoft Skills for Fabric for developers and consumers.",
+      "version": "0.3.0",
+      "repository": "https://github.com/microsoft/skills-for-fabric",
+      "keywords": [
+        "fabric",
+        "microsoft-fabric",
+        "medallion",
+        "data-warehouse",
+        "lakehouse",
+        "analytics",
+        "kql",
+        "kusto",
+        "eventhouse",
+        "real-time-intelligence"
+      ],
+      "license": "MIT"
+    },
+    {
+      "name": "fabric-authoring",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/skills-for-fabric",
+        "path": "plugins/fabric-authoring"
+      },
+      "description": "Developer skills for authoring Microsoft Fabric solutions - SDKs, APIs, automation scripts, CI/CD.",
+      "version": "0.3.0",
+      "repository": "https://github.com/microsoft/skills-for-fabric",
+      "keywords": [
+        "fabric",
+        "microsoft-fabric",
+        "authoring",
+        "developer",
+        "sdk",
+        "api"
+      ],
+      "license": "MIT"
+    },
+    {
+      "name": "fabric-consumption",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/skills-for-fabric",
+        "path": "plugins/fabric-consumption"
+      },
+      "description": "Consumer skills for interactive Microsoft Fabric operations - queries, exploration, monitoring.",
+      "version": "0.3.0",
+      "repository": "https://github.com/microsoft/skills-for-fabric",
+      "keywords": [
+        "fabric",
+        "microsoft-fabric",
+        "consumption",
+        "query",
+        "exploration"
+      ],
+      "license": "MIT"
+    },
+    {
+      "name": "fabric-operations",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/skills-for-fabric",
+        "path": "plugins/fabric-operations"
+      },
+      "description": "Operations skills for diagnosing Microsoft Fabric performance and health - system views, multi-step investigation workflows.",
+      "version": "0.3.0",
+      "repository": "https://github.com/microsoft/skills-for-fabric",
+      "keywords": [
+        "fabric",
+        "microsoft-fabric",
+        "operations",
+        "monitoring",
+        "diagnostics",
+        "performance"
+      ],
+      "license": "MIT"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Extend the power of GitHub Copilot with MCP servers, skills, hooks, and other ex
 - **Hooks** — Custom integrations and event-driven automations *(coming soon)*
 - **Extensibility Tools** — Building blocks for creating your own plugins *(coming soon)*
 
+## 🌐 External Plugins
+
+This marketplace also references plugins hosted in other repositories:
+
+- **[Microsoft Skills for Fabric](https://github.com/microsoft/skills-for-fabric)** — `fabric-skills`, `fabric-authoring`, `fabric-consumption`, `fabric-operations`. Skills and agents for Microsoft Fabric (Lakehouse, Warehouse, Power BI, Eventhouse, Eventstream, Dataflows, Spark).
+
 ## 🤝 Contributing
 
 We'd love your contributions! Please read our [Contributing Guide](CONTRIBUTING.md) for details on how to submit pull requests.


### PR DESCRIPTION
This pull request adds support for several Microsoft Fabric-related plugins by updating the plugin marketplace configuration and documentation. These changes make new external plugins discoverable and clarify their purpose for users.

**Marketplace plugin additions:**

* Added four new Microsoft Fabric plugins to `.github/plugin/marketplace.json`:
  - [`fabric-skills`](diffhunk://#diff-1f0f8287689a50a4b4e815821ff6c9d321349f4d036c5c405c6893f6994514b3R41-R123): Complete bundle of Microsoft Skills for Fabric for developers and consumers.
  - [`fabric-authoring`](diffhunk://#diff-1f0f8287689a50a4b4e815821ff6c9d321349f4d036c5c405c6893f6994514b3R41-R123): Developer skills for authoring Microsoft Fabric solutions, including SDKs, APIs, and automation scripts.
  - [`fabric-consumption`](diffhunk://#diff-1f0f8287689a50a4b4e815821ff6c9d321349f4d036c5c405c6893f6994514b3R41-R123): Consumer skills for interactive Microsoft Fabric operations such as queries and monitoring.
  - [`fabric-operations`](diffhunk://#diff-1f0f8287689a50a4b4e815821ff6c9d321349f4d036c5c405c6893f6994514b3R41-R123): Operations skills for diagnosing Microsoft Fabric performance and health.

**Documentation updates:**

* Updated the `README.md` to mention the inclusion of external plugins, specifically highlighting the Microsoft Skills for Fabric suite and listing the new plugins with a brief description.