### PR TITLE
Add copilot-hud plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -121,6 +121,29 @@
         "performance"
       ],
       "license": "MIT"
+    },
+    {
+      "name": "copilot-hud",
+      "source": {
+        "source": "github",
+        "repo": "griches/copilot-hud"
+      },
+      "description": "Real-time status HUD for GitHub Copilot CLI — shows project path, git branch, live context bar, tool activity, background agent tracking, and a remote-session indicator.",
+      "version": "1.2.5",
+      "repository": "https://github.com/griches/copilot-hud",
+      "keywords": [
+        "hud",
+        "statusline",
+        "copilot-cli",
+        "context",
+        "tools",
+        "agents",
+        "git"
+      ],
+      "license": "MIT",
+      "author": {
+        "name": "Gary Riches"
+      }
     }
   ]
 }


### PR DESCRIPTION
## What

Adds [`copilot-hud`](https://github.com/griches/copilot-hud) as an external-source plugin entry in `marketplace.json`.

## Why

`copilot-hud` is a real-time status HUD for the GitHub Copilot CLI's `statusLine` (experimental) feature. It renders a compact multi-line view with project path, git branch, a live context-window bar (using `current_context_used_percentage` / `displayed_context_limit`), running and completed tool activity, background agent tracking, and a remote-session indicator that lights up when a remote controller is attached via \`--remote\` / \`--connect\`.

```
[Opus 4.6 3x·high] │ ◉ remote │ my-project │ git:(main* ↑2) │ ⏱ 5m │ +42/-3
Ctx ████░░░░░░ 70.0k/200.0k 35% │ Reqs 3 │ in:1.5M out:12.2k cache:1.4M │ 42 tok/s
✓ ✎ Edit: auth.ts | ✓ ⌨ Bash: git status ×3 | ◐ ◉ Read: index.ts
```

## Plugin metadata

- Repo: https://github.com/griches/copilot-hud
- License: MIT
- Version: 1.2.5
- Author: Gary Riches
- Latest release: https://github.com/griches/copilot-hud/releases/tag/v1.2.5

## Schema notes

Entered as an external `source: { source: github, repo: griches/copilot-hud }` — same pattern used by the existing `fabric-*` entries. The plugin lives at the repo root (no `path` needed). Plugin's own `plugin.json` declares `commands/` and `hooks.json`.

Happy to adjust the entry, split it differently, or vendor any portion in-tree if the format isn't what you'd like.