### PR TITLE
Add Supabase plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -128,7 +128,7 @@
         "source": "github",
         "repo": "supabase-community/supabase-plugin"
       },
-      "description": "Supabase tools for GitHub Copilot — MCP server for managing your Supabase projects plus expert skills for Postgres best practices and full-stack Supabase development.",
+      "description": "Supabase tools for GitHub Copilot — MCP server for managing your Supabase projects and skills to guide you through every stage of building with Supabase.",
       "repository": "https://github.com/supabase-community/supabase-plugin",
       "keywords": [
         "supabase",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -121,6 +121,26 @@
         "performance"
       ],
       "license": "MIT"
+    },
+    {
+      "name": "supabase",
+      "source": {
+        "source": "github",
+        "repo": "supabase-community/supabase-plugin"
+      },
+      "description": "Supabase tools for GitHub Copilot — MCP server for managing your Supabase projects plus expert skills for Postgres best practices and full-stack Supabase development.",
+      "repository": "https://github.com/supabase-community/supabase-plugin",
+      "keywords": [
+        "supabase",
+        "postgres",
+        "database",
+        "auth",
+        "storage",
+        "edge-functions",
+        "realtime",
+        "mcp"
+      ],
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
## Add Supabase plugin

Adds the Supabase plugin as an external entry in `marketplace.json`, sourced from [`supabase-community/supabase-plugin`](https://github.com/supabase-community/supabase-plugin).

### What it provides

- **MCP Server** — Manage your Supabase projects directly from Copilot (databases, branches, migrations, edge functions, logs, and more) via the official Supabase MCP server.
- **Skills** — A set of skills to guide you through every stage of building with Supabase, including Postgres best practices and full-stack Supabase development patterns.

### Source repository

https://github.com/supabase-community/supabase-plugin