### PR TITLE
workiq skill: use prefixed MCP tool name

### DIFF
--- a/plugins/workiq/skills/workiq/SKILL.md
+++ b/plugins/workiq/skills/workiq/SKILL.md
@@ -15,18 +15,18 @@ WorkIQ connects AI agents to Microsoft 365 Copilot, providing access to workplac
 
 | User Question Pattern | Example | Action |
 |-----------------------|---------|--------|
-| What someone said/shared/communicated | "What did Rob say about X?" | `ask_work_iq` |
-| Someone's priorities/concerns/focus | "What's top of mind for Sarah?" | `ask_work_iq` |
-| Meeting content/decisions/action items | "What was decided in yesterday's meeting?" | `ask_work_iq` |
-| Email content or conversations | "Any emails from John about the deadline?" | `ask_work_iq` |
-| Teams messages or chats | "What did the team discuss about the release?" | `ask_work_iq` |
-| Document locations or content | "Where is the design doc?" | `ask_work_iq` |
-| Colleague expertise or ownership | "Who owns the billing system?" | `ask_work_iq` |
-| Calendar/schedule information | "What meetings do I have today?" | `ask_work_iq` |
-| Organizational context | "What are the team's Q1 goals?" | `ask_work_iq` |
-| Project status or updates | "What's the status of Project X?" | `ask_work_iq` |
-| Team activities or work | "What is the team working on?" | `ask_work_iq` |
-| Any workplace/work-related context | "Any updates I should know about?" | `ask_work_iq` |
+| What someone said/shared/communicated | "What did Rob say about X?" | `workiq-ask_work_iq` |
+| Someone's priorities/concerns/focus | "What's top of mind for Sarah?" | `workiq-ask_work_iq` |
+| Meeting content/decisions/action items | "What was decided in yesterday's meeting?" | `workiq-ask_work_iq` |
+| Email content or conversations | "Any emails from John about the deadline?" | `workiq-ask_work_iq` |
+| Teams messages or chats | "What did the team discuss about the release?" | `workiq-ask_work_iq` |
+| Document locations or content | "Where is the design doc?" | `workiq-ask_work_iq` |
+| Colleague expertise or ownership | "Who owns the billing system?" | `workiq-ask_work_iq` |
+| Calendar/schedule information | "What meetings do I have today?" | `workiq-ask_work_iq` |
+| Organizational context | "What are the team's Q1 goals?" | `workiq-ask_work_iq` |
+| Project status or updates | "What's the status of Project X?" | `workiq-ask_work_iq` |
+| Team activities or work | "What is the team working on?" | `workiq-ask_work_iq` |
+| Any workplace/work-related context | "Any updates I should know about?" | `workiq-ask_work_iq` |
 
 **DO NOT say "I don't have access to emails/meetings/messages"** - use WorkIQ instead!
 
@@ -38,11 +38,13 @@ Authentication is automatic with the connected user's credentials.
 
 ## MCP Tool
 
-Use the `ask_work_iq` MCP tool to query Microsoft 365 Copilot. The tool accepts a single `question` parameter.
+Use the `workiq-ask_work_iq` MCP tool to query Microsoft 365 Copilot. The tool accepts a single `question` parameter.
+
+> The MCP server is named `workiq`, so the tool is exposed to the agent as `workiq-ask_work_iq` (server name + `-` + tool name). Calling the bare `ask_work_iq` will fail with `Tool 'ask_work_iq' does not exist.`
 
 | Tool | Parameters |
 |------|------------|
-| `ask_work_iq` | `{ "question": "<your question>" }` |
+| `workiq-ask_work_iq` | `{ "question": "<your question>" }` |
 
 ## Quick Start
 
@@ -50,7 +52,7 @@ Query M365 Copilot using the MCP tool:
 
 | Tool | Parameters |
 |------|------------|
-| `ask_work_iq` | `{ "question": "Who is the expert on TypeSpec?" }` |
+| `workiq-ask_work_iq` | `{ "question": "Who is the expert on TypeSpec?" }` |
 
 ## Common Use Cases
 
@@ -58,50 +60,50 @@ Query M365 Copilot using the MCP tool:
 
 | Tool | Parameters |
 |------|------------|
-| `ask_work_iq` | `{ "question": "What are the latest top of mind from Rob I should be aware of?" }` |
-| `ask_work_iq` | `{ "question": "What has Sarah been focused on lately?" }` |
-| `ask_work_iq` | `{ "question": "What did John share about the project?" }` |
-| `ask_work_iq` | `{ "question": "What concerns has my manager raised recently?" }` |
+| `workiq-ask_work_iq` | `{ "question": "What are the latest top of mind from Rob I should be aware of?" }` |
+| `workiq-ask_work_iq` | `{ "question": "What has Sarah been focused on lately?" }` |
+| `workiq-ask_work_iq` | `{ "question": "What did John share about the project?" }` |
+| `workiq-ask_work_iq` | `{ "question": "What concerns has my manager raised recently?" }` |
 
 ### Find Experts and People
 
 | Tool | Parameters |
 |------|------------|
-| `ask_work_iq` | `{ "question": "Who is the expert on authentication in our team?" }` |
-| `ask_work_iq` | `{ "question": "Who should I talk to about the billing system?" }` |
-| `ask_work_iq` | `{ "question": "Who worked on the checkout feature?" }` |
+| `workiq-ask_work_iq` | `{ "question": "Who is the expert on authentication in our team?" }` |
+| `workiq-ask_work_iq` | `{ "question": "Who should I talk to about the billing system?" }` |
+| `workiq-ask_work_iq` | `{ "question": "Who worked on the checkout feature?" }` |
 
 ### Retrieve Meeting Context
 
 | Tool | Parameters |
 |------|------------|
-| `ask_work_iq` | `{ "question": "What decisions were made in my meeting last week about the new feature?" }` |
-| `ask_work_iq` | `{ "question": "Summarize the architecture discussion from yesterday's standup" }` |
-| `ask_work_iq` | `{ "question": "What action items came out of the sprint planning?" }` |
+| `workiq-ask_work_iq` | `{ "question": "What decisions were made in my meeting last week about the new feature?" }` |
+| `workiq-ask_work_iq` | `{ "question": "Summarize the architecture discussion from yesterday's standup" }` |
+| `workiq-ask_work_iq` | `{ "question": "What action items came out of the sprint planning?" }` |
 
 ### Find Emails and Messages
 
 | Tool | Parameters |
 |------|------------|
-| `ask_work_iq` | `{ "question": "Any recent emails from Rob about the deadline?" }` |
-| `ask_work_iq` | `{ "question": "What did the team discuss in Teams about the release?" }` |
-| `ask_work_iq` | `{ "question": "Summarize my unread messages from today" }` |
+| `workiq-ask_work_iq` | `{ "question": "Any recent emails from Rob about the deadline?" }` |
+| `workiq-ask_work_iq` | `{ "question": "What did the team discuss in Teams about the release?" }` |
+| `workiq-ask_work_iq` | `{ "question": "Summarize my unread messages from today" }` |
 
 ### Locate Documents and Specs
 
 | Tool | Parameters |
 |------|------------|
-| `ask_work_iq` | `{ "question": "Find the design doc for the authentication system" }` |
-| `ask_work_iq` | `{ "question": "What's the latest spec for Project X?" }` |
-| `ask_work_iq` | `{ "question": "Where is the API documentation for the payments service?" }` |
+| `workiq-ask_work_iq` | `{ "question": "Find the design doc for the authentication system" }` |
+| `workiq-ask_work_iq` | `{ "question": "What's the latest spec for Project X?" }` |
+| `workiq-ask_work_iq` | `{ "question": "Where is the API documentation for the payments service?" }` |
 
 ### Understand Priorities
 
 | Tool | Parameters |
 |------|------------|
-| `ask_work_iq` | `{ "question": "Based on discussions with my manager, what are my top priorities?" }` |
-| `ask_work_iq` | `{ "question": "What are the team's goals for this quarter?" }` |
-| `ask_work_iq` | `{ "question": "What's blocking the release?" }` |
+| `workiq-ask_work_iq` | `{ "question": "Based on discussions with my manager, what are my top priorities?" }` |
+| `workiq-ask_work_iq` | `{ "question": "What are the team's goals for this quarter?" }` |
+| `workiq-ask_work_iq` | `{ "question": "What's blocking the release?" }` |
 
 ### Ground Implementation in Context
 
@@ -109,13 +111,13 @@ When implementing features, use WorkIQ to ground your work in organizational kno
 
 | Tool | Parameters |
 |------|------------|
-| `ask_work_iq` | `{ "question": "Based on the latest spec for Project X, what are the backend requirements?" }` |
+| `workiq-ask_work_iq` | `{ "question": "Based on the latest spec for Project X, what are the backend requirements?" }` |
 
 Then implement based on the response.
 
 ## MCP Tool Reference
 
-### ask_work_iq
+### `workiq-ask_work_iq`
 
 Query Microsoft 365 Copilot for workplace intelligence.
 
@@ -127,4 +129,4 @@ Query Microsoft 365 Copilot for workplace intelligence.
 
 | Tool | Parameters |
 |------|------------|
-| `ask_work_iq` | `{ "question": "Who is my manager?" }` |
+| `workiq-ask_work_iq` | `{ "question": "Who is my manager?" }` |


### PR DESCRIPTION
Copilot CLI said this change was worth doing due to trajectory issues using these skills. I'm not sure so I opened the PR to let maintainers judge. Failure rate is pretty low, but it seems like there is probably a better change then renaming everything like this.

--- 

## Problem

The WorkIQ skill (`plugins/workiq/skills/workiq/SKILL.md`) documents the MCP tool as bare `ask_work_iq`. The Copilot CLI exposes MCP tools as `<server>-<tool>`, and the WorkIQ MCP server is registered as `workiq` (per `plugins/workiq/.mcp.json`), so the actual tool name is `workiq-ask_work_iq`.

When an LLM trusts the skill examples and calls bare `ask_work_iq`, the call fails immediately with:

> Tool 'ask_work_iq' does not exist.

## Evidence

From the past week of Copilot CLI session telemetry:

| Tool name | Outcome | Count |
|-----------|---------|------:|
| `workiq-ask_work_iq` | success | 249 |
| `workiq-ask_work_iq` | failure (timeout / other) | 50 |
| `ask_work_iq` | failure (tool not found) | 4 |

The 4 bare-name failures all came from sessions where the agent followed the skill's examples literally.

## Fix

- Rename every example/table reference from `ask_work_iq` to `workiq-ask_work_iq`.
- Add a one-line note above the **MCP Tool** section explaining the `<server>-<tool>` prefix convention and the exact error message you get if you forget it, so future skill maintainers don't accidentally re-introduce the bare name.

No behavior change for the MCP server itself — purely a docs/skill fix.