### PR TITLE
Register armorcopilot in the marketplace

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -447,6 +447,30 @@
         "flowagent"
       ],
       "license": "MIT"
+    },
+    {
+      "name": "armorcopilot",
+      "source": {
+        "source": "github",
+        "repo": "armoriq/armorCopilot",
+        "path": "plugins/armorcopilot",
+        "ref": "v0.1.0"
+      },
+      "description": "Intent-based security policy and audit for GitHub Copilot CLI and VS Code agent mode. Hooks every tool call against a declared intent plan and natural-language policy rules; blocks intent drift; ships signed audit logs.",
+      "version": "0.1.0",
+      "repository": "https://github.com/armoriq/armorCopilot",
+      "homepage": "https://docs.armoriq.ai/armorcopilot",
+      "keywords": [
+        "security",
+        "policy",
+        "audit",
+        "intent",
+        "armoriq",
+        "mcp",
+        "hooks",
+        "github-copilot"
+      ],
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds **ArmorCopilot** to the marketplace registry. ArmorCopilot is intent-based security policy + audit for GitHub Copilot CLI and VS Code agent mode. It hooks every tool call against a declared intent plan and natural-language policy rules, blocks intent drift, and ships signed audit logs.

Pinned to immutable tag `v0.1.0` from [armoriq/armorCopilot](https://github.com/armoriq/armorCopilot), path `plugins/armorcopilot`.

## What it does

- Hooks: `sessionStart`, `userPromptSubmitted`, `preToolUse`, `postToolUse`, `permissionRequest`, `postToolUseFailure`, `agentStop`, `sessionEnd`
- MCP tools: `register_intent_plan`, `policy_update`, `policy_read`
- Auto-discovered by VS Code Copilot Chat agent mode from `~/.copilot/installed-plugins/`
- Natural-language policy rules from chat (`Policy new: deny webfetch`)
- Async batched audit pipeline to the ArmorIQ backend

## Marketplace entry

```json
{
  "name": "armorcopilot",
  "source": {
    "source": "github",
    "repo": "armoriq/armorCopilot",
    "path": "plugins/armorcopilot",
    "ref": "v0.1.0"
  },
  "description": "Intent-based security policy and audit for GitHub Copilot CLI and VS Code agent mode...",
  "version": "0.1.0",
  "repository": "https://github.com/armoriq/armorCopilot",
  "homepage": "https://docs.armoriq.ai/armorcopilot",
  "keywords": ["security", "policy", "audit", "intent", "armoriq", "mcp", "hooks", "github-copilot"],
  "license": "MIT"
}
```

## Links

- Source: https://github.com/armoriq/armorCopilot
- Docs: https://docs.armoriq.ai/armorcopilot
- Tag (immutable ref): https://github.com/armoriq/armorCopilot/releases/tag/v0.1.0
- Plugin manifest: https://github.com/armoriq/armorCopilot/blob/v0.1.0/plugins/armorcopilot/.claude-plugin/plugin.json
- One-line installer (already live): `curl -fsSL https://armoriq.ai/install_armorcopilot.sh | bash`

## Verification

- [x] `python3 -m json.tool .github/plugin/marketplace.json` passes
- [x] Plugin repo is public
- [x] Tag `v0.1.0` exists at the pinned commit (`1ea972464670e7fce497c4c99dafcab60cc4b123`)
- [x] License is MIT (matches plugin's package.json + repo LICENSE)
- [x] Plugin already passes end-to-end install + policy-block tests on the CLI surface