### PR TITLE
Add TypeUI plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -40,6 +40,41 @@
       "mcpServers": ".mcp.json"
     },
     {
+      "name": "typeui",
+      "source": {
+        "source": "github",
+        "repo": "bergside/typeui",
+        "path": "plugins/vscode/typeui"
+      },
+      "description": "Connect GitHub Copilot in VS Code to TypeUI for curated design systems, UI prompts, and layout variations.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Bergside LLC",
+        "email": "zoltan@bergside.com",
+        "url": "https://www.typeui.sh"
+      },
+      "homepage": "https://www.typeui.sh",
+      "repository": "https://github.com/bergside/typeui",
+      "license": "MIT",
+      "category": "Design",
+      "keywords": [
+        "typeui",
+        "vscode",
+        "github-copilot",
+        "mcp",
+        "ui",
+        "design-systems",
+        "prompts"
+      ],
+      "tags": [
+        "mcp",
+        "ui",
+        "design-systems",
+        "prompts",
+        "frontend"
+      ]
+    },
+    {
       "name": "fabric-skills",
       "source": {
         "source": "github",

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Extend the power of GitHub Copilot with MCP servers, skills, hooks, and other ex
 
 This marketplace also references plugins hosted in other repositories:
 
+- **[TypeUI](https://github.com/bergside/typeui)** — `typeui`. Connects GitHub Copilot in VS Code to TypeUI for curated design systems, UI prompts, and layout variations.
 - **[Microsoft Skills for Fabric](https://github.com/microsoft/skills-for-fabric)** — `fabric-skills`, `fabric-authoring`, `fabric-consumption`, `fabric-operations`. Skills and agents for Microsoft Fabric (Lakehouse, Warehouse, Power BI, Eventhouse, Eventstream, Dataflows, Spark).
 
 ## 🤝 Contributing


### PR DESCRIPTION
Hey guys!

I appreciate y'all looking into this PR.

TypeUI is a plugin which primarily uses an MCP to improve UI generation. It's also on the MCP Registry.

## Summary

Adds TypeUI to the Copilot plugins marketplace as an external plugin hosted at `bergside/typeui`.

TypeUI connects GitHub Copilot in VS Code to the hosted TypeUI MCP server for curated design systems, UI prompts, and layout variations.

## Changes

- Added a `typeui` plugin entry to `.github/plugin/marketplace.json`
- Pointed the plugin source to `bergside/typeui` at `plugins/vscode/typeui`
- Added TypeUI to the README external plugins list

## Validation

- Parsed `.github/plugin/marketplace.json` successfully as JSON
- Ran `git diff --check` with no whitespace issues

Thanks 🙏