### PR TITLE
Add Power BI Authoring Plugin to Marketplace

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -121,6 +121,29 @@
         "performance"
       ],
       "license": "MIT"
+    },
+    {
+      "name": "powerbi-authoring",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/skills-for-fabric",
+        "path": "plugins/powerbi-authoring"
+      },
+      "description": "Developer skills for authoring Microsoft Power BI solutions.",
+      "version": "0.3.3",
+      "repository": "https://github.com/microsoft/skills-for-fabric",
+      "keywords": [
+        "fabric",
+        "microsoft-fabric",
+        "authoring",
+        "powerbi",
+        "semantic-model",
+        "pbip",
+        "pbir",
+        "report",
+        "developer"
+      ],
+      "license": "MIT"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Extend the power of GitHub Copilot with MCP servers, skills, hooks, and other ex
 
 This marketplace also references plugins hosted in other repositories:
 
-- **[Microsoft Skills for Fabric](https://github.com/microsoft/skills-for-fabric)** — `fabric-skills`, `fabric-authoring`, `fabric-consumption`, `fabric-operations`. Skills and agents for Microsoft Fabric (Lakehouse, Warehouse, Power BI, Eventhouse, Eventstream, Dataflows, Spark).
+- **[Microsoft Skills for Fabric](https://github.com/microsoft/skills-for-fabric)** — `fabric-skills`, `fabric-authoring`, `fabric-consumption`, `fabric-operations`, `powerbi-authoring`. Skills and agents for Microsoft Fabric (Lakehouse, Warehouse, Power BI, Eventhouse, Eventstream, Dataflows, Spark).
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
This pull request adds a new plugin, `powerbi-authoring`, to the marketplace. The plugin is also referenced in the documentation as part of the Microsoft Skills for Fabric suite.

**Marketplace updates:**

* Added the `powerbi-authoring` plugin to `.github/plugin/marketplace.json`, including metadata such as description, repository, version, keywords, and license.

**Documentation updates:**

* Updated the `README.md` to include `powerbi-authoring` in the list of Microsoft Skills for Fabric plugins.