### PR TITLE
Add cpp-language-server plugin configuration

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -210,6 +210,26 @@
         "developer"
       ],
       "license": "MIT"
+    },
+    {
+      "name": "cpp-language-server",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/cpp-language-server",
+        "path": "plugins/cpp-language-server"
+      },
+      "description": "Navigate and interact with your C++ code using the Microsoft C++ Language Server.",
+      "version": "0.1.0",
+      "repository": "https://github.com/microsoft/cpp-language-server",
+      "keywords": [
+        "cpp",
+        "c++",
+        "refactoring",
+        "code-analysis",
+        "lsp",
+        "language-server"
+      ],
+      "license": "See EULA/LICENSE.txt in @microsoft/cpp-language-server NPM package"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This marketplace also references plugins hosted in other repositories:
 
 - **[Microsoft Skills for Fabric](https://github.com/microsoft/skills-for-fabric)** — `fabric-skills`, `fabric-authoring`, `fabric-consumption`, `fabric-operations`, `powerbi-authoring`. Skills and agents for Microsoft Fabric (Lakehouse, Warehouse, Power BI, Eventhouse, Eventstream, Dataflows, Spark).
 
+- **[Microsoft C++ Language Server](https://github.com/microsoft/cpp-language-server) - Navigate and interact with your C++ code.
+
 ## 🤝 Contributing
 
 We'd love your contributions! Please read our [Contributing Guide](CONTRIBUTING.md) for details on how to submit pull requests.


### PR DESCRIPTION
This plugin hosts the Microsoft C++ Language Server, which is an LSP server for C++ based on the same engine used for C++ in VS Code and Visual Studio. See this blog post for the initial announcement https://devblogs.microsoft.com/cppblog/c-code-intelligence-for-github-copilot-cli-preview/

We're aiming to make the language server easier to install by providing it as a plugin and available in built-in marketplaces.