### PR TITLE
Add Datadog plugin to marketplace

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -210,6 +210,28 @@
         "developer"
       ],
       "license": "MIT"
+    },
+    {
+      "name": "datadog",
+      "description": "Use Datadog directly in VS Code through a preconfigured Datadog MCP server. Query logs, metrics, traces, dashboards, and more through natural conversation.",
+      "version": "0.7.13",
+      "author": {
+        "name": "Datadog",
+        "url": "https://www.datadoghq.com"
+      },
+      "homepage": "https://github.com/datadog-labs/vscode-plugin",
+      "keywords": [
+        "datadog",
+        "infrastructure",
+        "mcp",
+        "observability",
+        "productivity"
+      ],
+      "repository": "https://github.com/datadog-labs/vscode-plugin",
+      "source": {
+        "source": "github",
+        "repo": "datadog-labs/vscode-plugin"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds an entry for the [Datadog VS Code plugin](https://github.com/datadog-labs/vscode-plugin) to `marketplace.json`
- Metadata (name, description, version, keywords) sourced directly from the plugin's own `plugin.json`
- Current version: `0.7.13`

## Test plan

- [ ] Verify JSON is valid and the new entry follows the same structure as existing entries