### PR TITLE
Add Power Platform Skills plugins to marketplace

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -243,7 +243,7 @@
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
       },
-      "homepage": "https://github.com/microsoft/power-platform-skills/",
+      "homepage": "https://github.com/microsoft/power-platform-skills",
       "repository": "https://github.com/microsoft/power-platform-skills",
       "keywords": [
         "power-pages",
@@ -286,7 +286,7 @@
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
       },
-      "homepage": "https://github.com/microsoft/power-platform-skills/",
+      "homepage": "https://github.com/microsoft/power-platform-skills",
       "repository": "https://github.com/microsoft/power-platform-skills",
       "keywords": [
         "model-apps",
@@ -313,7 +313,7 @@
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
       },
-      "homepage": "https://github.com/microsoft/power-platform-skills/",
+      "homepage": "https://github.com/microsoft/power-platform-skills",
       "repository": "https://github.com/microsoft/power-platform-skills",
       "keywords": [
         "mcp-apps",
@@ -338,7 +338,7 @@
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
       },
-      "homepage": "https://github.com/microsoft/power-platform-skills/",
+      "homepage": "https://github.com/microsoft/power-platform-skills",
       "repository": "https://github.com/microsoft/power-platform-skills",
       "keywords": [
         "canvas-apps",
@@ -361,7 +361,7 @@
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
       },
-      "homepage": "https://github.com/microsoft/power-platform-skills/",
+      "homepage": "https://github.com/microsoft/power-platform-skills",
       "repository": "https://github.com/microsoft/power-platform-skills",
       "keywords": [
         "power-apps",
@@ -387,7 +387,7 @@
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
       },
-      "homepage": "https://github.com/microsoft/power-platform-skills/",
+      "homepage": "https://github.com/microsoft/power-platform-skills",
       "repository": "https://github.com/microsoft/power-platform-skills",
       "keywords": [
         "power-platform",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -401,6 +401,30 @@
         "microsoft"
       ],
       "license": "MIT"
+    },
+    {
+      "name": "power-automate",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/power-platform-skills",
+        "path": "plugins/power-automate"
+      },
+      "description": "Build, edit, run, and debug Power Automate cloud flows via the FlowAgent MCP server — connection lifecycle, surgical edits, copy across environments, run management, and validated expressions.",
+      "author": {
+        "name": "Microsoft",
+        "url": "https://www.microsoft.com"
+      },
+      "homepage": "https://github.com/microsoft/power-platform-skills",
+      "repository": "https://github.com/microsoft/power-platform-skills",
+      "keywords": [
+        "power-automate",
+        "cloud-flows",
+        "flows",
+        "mcp",
+        "power-platform",
+        "flowagent"
+      ],
+      "license": "MIT"
     }
   ]
 }

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -230,6 +230,183 @@
         "language-server"
       ],
       "license": "See EULA/LICENSE.txt in @microsoft/cpp-language-server NPM package"
+    },
+    {
+      "name": "power-pages",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/power-platform-skills",
+        "path": "plugins/power-pages"
+      },
+      "description": "Create and deploy Power Pages sites using modern development approaches. Supports code sites (SPAs) with React, Angular, Vue, or Astro. Includes ALM orchestration (plan-alm) with a solution-splitting decision tree, per-solution pipelines, Azure Blob asset advisory, manifest schema v2 for multi-solution deployments, and force-link remediation for cross-host pipeline migrations.",
+      "version": "2.6.0",
+      "author": {
+        "name": "Microsoft",
+        "url": "https://www.microsoft.com"
+      },
+      "homepage": "https://github.com/microsoft/power-platform-skills/",
+      "repository": "https://github.com/microsoft/power-platform-skills",
+      "keywords": [
+        "power-pages",
+        "site-builder",
+        "code-sites",
+        "spa",
+        "react",
+        "angular",
+        "vue",
+        "astro",
+        "pac-cli",
+        "dataverse",
+        "odata",
+        "web-api",
+        "tables",
+        "schema",
+        "solution",
+        "alm",
+        "plan-alm",
+        "ci-cd",
+        "pipeline",
+        "pipelines-host",
+        "force-link",
+        "diagnostics",
+        "shared-lib",
+        "solution-splitting",
+        "asset-advisory"
+      ],
+      "license": "MIT"
+    },
+    {
+      "name": "model-apps",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/power-platform-skills",
+        "path": "plugins/model-apps"
+      },
+      "description": "Build and deploy Power Apps generative pages for model-driven apps with specialist agents for planning, entity creation, and parallel code generation. Requires PAC CLI >= 2.7.0 and Azure CLI (`az`). See CHANGELOG.md for v1.x -> v2.x migration.",
+      "version": "2.2.0",
+      "author": {
+        "name": "Microsoft",
+        "url": "https://www.microsoft.com"
+      },
+      "homepage": "https://github.com/microsoft/power-platform-skills/",
+      "repository": "https://github.com/microsoft/power-platform-skills",
+      "keywords": [
+        "model-apps",
+        "generative-pages",
+        "genux",
+        "genpage",
+        "react",
+        "fluent-ui",
+        "dataverse",
+        "pac-cli",
+        "model-driven"
+      ],
+      "license": "MIT"
+    },
+    {
+      "name": "mcp-apps",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/power-platform-skills",
+        "path": "plugins/mcp-apps"
+      },
+      "description": "Generate MCP App widgets for MCP tools. Produces self-contained HTML widgets using the MCP Apps protocol.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Microsoft",
+        "url": "https://www.microsoft.com"
+      },
+      "homepage": "https://github.com/microsoft/power-platform-skills/",
+      "repository": "https://github.com/microsoft/power-platform-skills",
+      "keywords": [
+        "mcp-apps",
+        "mcp",
+        "widget",
+        "ext-apps",
+        "fluent-ui",
+        "html",
+        "tool-visualization"
+      ],
+      "license": "MIT"
+    },
+    {
+      "name": "canvas-apps",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/power-platform-skills",
+        "path": "plugins/canvas-apps"
+      },
+      "description": "Build Power Apps Canvas Apps using the Canvas Authoring MCP server.",
+      "version": "2.1.0",
+      "author": {
+        "name": "Microsoft",
+        "url": "https://www.microsoft.com"
+      },
+      "homepage": "https://github.com/microsoft/power-platform-skills/",
+      "repository": "https://github.com/microsoft/power-platform-skills",
+      "keywords": [
+        "canvas-apps",
+        "power-apps",
+        "canvas",
+        "pa-yaml",
+        "msapp"
+      ],
+      "license": "MIT"
+    },
+    {
+      "name": "code-apps-preview",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/power-platform-skills",
+        "path": "plugins/code-apps"
+      },
+      "description": "Build and deploy Power Apps code apps using React, Vite, and Power Platform connectors.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Microsoft",
+        "url": "https://www.microsoft.com"
+      },
+      "homepage": "https://github.com/microsoft/power-platform-skills/",
+      "repository": "https://github.com/microsoft/power-platform-skills",
+      "keywords": [
+        "power-apps",
+        "code-apps",
+        "react",
+        "vite",
+        "dataverse",
+        "connectors",
+        "pac-cli",
+        "power-platform"
+      ],
+      "license": "MIT"
+    },
+    {
+      "name": "mobile-app",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/power-platform-skills",
+        "path": "plugins/mobile-apps"
+      },
+      "description": "Build and deploy Power Apps code apps for mobile using Expo (React Native), with native device functionality and Power Platform connectors",
+      "version": "0.1.0",
+      "author": {
+        "name": "Microsoft",
+        "url": "https://www.microsoft.com"
+      },
+      "homepage": "https://github.com/microsoft/power-platform-skills/",
+      "repository": "https://github.com/microsoft/power-platform-skills",
+      "keywords": [
+        "power platform",
+        "power apps",
+        "code apps",
+        "mobile",
+        "expo",
+        "react native",
+        "native",
+        "connectors",
+        "microsoft"
+      ],
+      "license": "MIT"
     }
   ]
 }

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -390,12 +390,12 @@
       "homepage": "https://github.com/microsoft/power-platform-skills/",
       "repository": "https://github.com/microsoft/power-platform-skills",
       "keywords": [
-        "power platform",
-        "power apps",
-        "code apps",
+        "power-platform",
+        "power-apps",
+        "code-apps",
         "mobile",
         "expo",
-        "react native",
+        "react-native",
         "native",
         "connectors",
         "microsoft"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -239,7 +239,6 @@
         "path": "plugins/power-pages"
       },
       "description": "Create and deploy Power Pages sites using modern development approaches. Supports code sites (SPAs) with React, Angular, Vue, or Astro. Includes ALM orchestration (plan-alm) with a solution-splitting decision tree, per-solution pipelines, Azure Blob asset advisory, manifest schema v2 for multi-solution deployments, and force-link remediation for cross-host pipeline migrations.",
-      "version": "2.6.0",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -283,7 +282,6 @@
         "path": "plugins/model-apps"
       },
       "description": "Build and deploy Power Apps generative pages for model-driven apps with specialist agents for planning, entity creation, and parallel code generation. Requires PAC CLI >= 2.7.0 and Azure CLI (`az`). See CHANGELOG.md for v1.x -> v2.x migration.",
-      "version": "2.2.0",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -311,7 +309,6 @@
         "path": "plugins/mcp-apps"
       },
       "description": "Generate MCP App widgets for MCP tools. Produces self-contained HTML widgets using the MCP Apps protocol.",
-      "version": "1.0.0",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -337,7 +334,6 @@
         "path": "plugins/canvas-apps"
       },
       "description": "Build Power Apps Canvas Apps using the Canvas Authoring MCP server.",
-      "version": "2.1.0",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -361,7 +357,6 @@
         "path": "plugins/code-apps"
       },
       "description": "Build and deploy Power Apps code apps using React, Vite, and Power Platform connectors.",
-      "version": "1.0.0",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -388,7 +383,6 @@
         "path": "plugins/mobile-apps"
       },
       "description": "Build and deploy Power Apps code apps for mobile using Expo (React Native), with native device functionality and Power Platform connectors",
-      "version": "0.1.0",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This marketplace also references plugins hosted in other repositories:
 
 - **[Microsoft C++ Language Server](https://github.com/microsoft/cpp-language-server)** — Navigate and interact with your C++ code.
 
+- **[Power Platform Skills](https://github.com/microsoft/power-platform-skills)** — `power-pages`, `model-apps`, `mcp-apps`, `canvas-apps`, `code-apps-preview`, `mobile-app`. Plugins for Power Platform development (Power Pages sites, model-driven and canvas apps, code apps, MCP App widgets, and mobile apps).
+
 ## 🤝 Contributing
 
 We'd love your contributions! Please read our [Contributing Guide](CONTRIBUTING.md) for details on how to submit pull requests.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This marketplace also references plugins hosted in other repositories:
 
 - **[Microsoft C++ Language Server](https://github.com/microsoft/cpp-language-server)** — Navigate and interact with your C++ code.
 
-- **[Power Platform Skills](https://github.com/microsoft/power-platform-skills)** — `power-pages`, `model-apps`, `mcp-apps`, `canvas-apps`, `code-apps-preview`, `mobile-app`. Plugins for Power Platform development (Power Pages sites, model-driven and canvas apps, code apps, MCP App widgets, and mobile apps).
+- **[Power Platform Skills](https://github.com/microsoft/power-platform-skills)** — `power-pages`, `model-apps`, `mcp-apps`, `canvas-apps`, `code-apps-preview`, `mobile-app`, `power-automate`. Plugins for Power Platform development (Power Pages sites, model-driven and canvas apps, code apps, MCP App widgets, mobile apps, and Power Automate cloud flows).
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
## Summary

Adds the seven plugins from [`microsoft/power-platform-skills`'s `marketplace.json`](https://github.com/microsoft/power-platform-skills/blob/main/marketplace.json) as external plugin references in this marketplace, following the existing pattern used for `fabric-skills`, `cpp-language-server`, etc.

- **`power-pages`** — `plugins/power-pages`
- **`model-apps`** — `plugins/model-apps`
- **`mcp-apps`** — `plugins/mcp-apps`
- **`canvas-apps`** — `plugins/canvas-apps`
- **`code-apps-preview`** — `plugins/code-apps`
- **`mobile-app`** — `plugins/mobile-apps`
- **`power-automate`** — `plugins/power-automate`

Each entry's name, description, and keywords are copied from the corresponding upstream `plugin.json` manifest. Versions are intentionally omitted so this file doesn't need updating whenever a plugin releases — the version lives in each plugin's own manifest. Note the two intentional name↔folder mismatches carried over from upstream: `code-apps-preview` → `plugins/code-apps` and `mobile-app` → `plugins/mobile-apps`.

## Changes
- `.github/plugin/marketplace.json` — added the 7 plugin entries.
- `README.md` — added a Power Platform Skills entry under **External Plugins**.

## Testing
- JSON validates (`python3 -m json.tool`).
- All 7 `repo:path` sources resolve in `microsoft/power-platform-skills`.
- Verified locally by registering a renamed copy of the marketplace and running `copilot plugin marketplace browse` — all plugins list correctly.
