### PR TITLE
Add Three.js Sculpt DNA plugin

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -425,6 +425,30 @@
         "flowagent"
       ],
       "license": "MIT"
+    },
+    {
+      "name": "threejs-sculpt-dna",
+      "source": {
+        "source": "github",
+        "repo": "hyeonsangjeon/Three.js-Object-Sculptor-github-Copilot-Plugin"
+      },
+      "description": "Reconstruct reference images as quality-gated procedural Three.js models and coverage-curated deterministic asset families.",
+      "version": "0.4.2",
+      "author": {
+        "name": "hyeonsangjeon",
+        "url": "https://github.com/hyeonsangjeon"
+      },
+      "homepage": "https://hyeonsangjeon.github.io/Three.js-Object-Sculptor-github-Copilot-Plugin/",
+      "repository": "https://github.com/hyeonsangjeon/Three.js-Object-Sculptor-github-Copilot-Plugin",
+      "keywords": [
+        "github-copilot",
+        "threejs",
+        "procedural-3d",
+        "object-reconstruction",
+        "asset-variants",
+        "sculpt-dna"
+      ],
+      "license": "MIT"
     }
   ]
 }

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -433,7 +433,7 @@
         "repo": "hyeonsangjeon/threejs-sculpt-dna"
       },
       "description": "Build verifiable modular procedural Three.js reconstructions and coverage-curated deterministic asset families from references.",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "author": {
         "name": "hyeonsangjeon",
         "url": "https://github.com/hyeonsangjeon"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -432,8 +432,8 @@
         "source": "github",
         "repo": "hyeonsangjeon/threejs-sculpt-dna"
       },
-      "description": "Reconstruct reference images as quality-gated procedural Three.js models and coverage-curated deterministic asset families.",
-      "version": "0.4.3",
+      "description": "Build verifiable modular procedural Three.js reconstructions and coverage-curated deterministic asset families from references.",
+      "version": "0.5.0",
       "author": {
         "name": "hyeonsangjeon",
         "url": "https://github.com/hyeonsangjeon"
@@ -442,10 +442,13 @@
       "repository": "https://github.com/hyeonsangjeon/threejs-sculpt-dna",
       "keywords": [
         "github-copilot",
+        "codex",
         "threejs",
         "procedural-3d",
+        "procedural-modeling",
         "object-reconstruction",
         "asset-variants",
+        "visual-regression",
         "sculpt-dna"
       ],
       "license": "MIT"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -430,16 +430,16 @@
       "name": "threejs-sculpt-dna",
       "source": {
         "source": "github",
-        "repo": "hyeonsangjeon/Three.js-Object-Sculptor-github-Copilot-Plugin"
+        "repo": "hyeonsangjeon/threejs-sculpt-dna"
       },
       "description": "Reconstruct reference images as quality-gated procedural Three.js models and coverage-curated deterministic asset families.",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "author": {
         "name": "hyeonsangjeon",
         "url": "https://github.com/hyeonsangjeon"
       },
-      "homepage": "https://hyeonsangjeon.github.io/Three.js-Object-Sculptor-github-Copilot-Plugin/",
-      "repository": "https://github.com/hyeonsangjeon/Three.js-Object-Sculptor-github-Copilot-Plugin",
+      "homepage": "https://hyeonsangjeon.github.io/threejs-sculpt-dna/",
+      "repository": "https://github.com/hyeonsangjeon/threejs-sculpt-dna",
       "keywords": [
         "github-copilot",
         "threejs",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This marketplace also references plugins hosted in other repositories:
 
 - **[Power Platform Skills](https://github.com/microsoft/power-platform-skills)** — `power-pages`, `model-apps`, `mcp-apps`, `canvas-apps`, `code-apps-preview`, `mobile-app`, `power-automate`. Plugins for Power Platform development (Power Pages sites, model-driven and canvas apps, code apps, MCP App widgets, mobile apps, and Power Automate cloud flows).
 
+- **[Three.js Sculpt DNA](https://github.com/hyeonsangjeon/Three.js-Object-Sculptor-github-Copilot-Plugin)** — Reconstruct reference images as quality-gated procedural Three.js models and generate deterministic variant families.
+
 ## 🤝 Contributing
 
 We'd love your contributions! Please read our [Contributing Guide](CONTRIBUTING.md) for details on how to submit pull requests.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This marketplace also references plugins hosted in other repositories:
 
 - **[Power Platform Skills](https://github.com/microsoft/power-platform-skills)** — `power-pages`, `model-apps`, `mcp-apps`, `canvas-apps`, `code-apps-preview`, `mobile-app`, `power-automate`. Plugins for Power Platform development (Power Pages sites, model-driven and canvas apps, code apps, MCP App widgets, mobile apps, and Power Automate cloud flows).
 
-- **[Three.js Sculpt DNA](https://github.com/hyeonsangjeon/Three.js-Object-Sculptor-github-Copilot-Plugin)** — Reconstruct reference images as quality-gated procedural Three.js models and generate deterministic variant families.
+- **[Three.js Sculpt DNA](https://github.com/hyeonsangjeon/threejs-sculpt-dna)** — Reconstruct reference images as quality-gated procedural Three.js models and generate deterministic variant families.
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This marketplace also references plugins hosted in other repositories:
 
 - **[Power Platform Skills](https://github.com/microsoft/power-platform-skills)** — `power-pages`, `model-apps`, `mcp-apps`, `canvas-apps`, `code-apps-preview`, `mobile-app`, `power-automate`. Plugins for Power Platform development (Power Pages sites, model-driven and canvas apps, code apps, MCP App widgets, mobile apps, and Power Automate cloud flows).
 
-- **[Three.js Sculpt DNA](https://github.com/hyeonsangjeon/threejs-sculpt-dna)** — Reconstruct reference images as quality-gated procedural Three.js models and generate deterministic variant families.
+- **[Three.js Sculpt DNA](https://github.com/hyeonsangjeon/threejs-sculpt-dna)** — Build verifiable modular procedural Three.js reconstructions and deterministic asset families from references.
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
## Summary

- Add `threejs-sculpt-dna` v0.5.1 as an external plugin for verifiable modular procedural Three.js reconstruction and coverage-curated deterministic asset families.
- Document the plugin in the External Plugins section and link its [public live demos](https://hyeonsangjeon.github.io/threejs-sculpt-dna/).
- Reference the [public source repository](https://github.com/hyeonsangjeon/threejs-sculpt-dna) root `plugin.json`, so the GitHub marketplace source intentionally has no `path`.

## Plugin details

- **Release:** [`v0.5.1`](https://github.com/hyeonsangjeon/threejs-sculpt-dna/releases/tag/v0.5.1)
- **Immutable release commit:** [`269963bd61763aef023f8457f7c3a7018e6b5b8d`](https://github.com/hyeonsangjeon/threejs-sculpt-dna/commit/269963bd61763aef023f8457f7c3a7018e6b5b8d)
- **License:** MIT
- **Included skills:** `object-to-threejs-procedural`, `sculpt-dna-variants`

## Reviewer evidence

- [Public Quality run](https://github.com/hyeonsangjeon/threejs-sculpt-dna/actions/runs/30566950457): 274 tests, generated TypeScript parsing, four locked browser builds, capture checks, and dependency audits passed.
- Exact `@microsoft/vally@0.6.0` validation passes 3/3 for both bundled skills; all 10 object-skill reference documents are directly reachable with zero orphan references.
- [Verified capability matrix](https://github.com/hyeonsangjeon/threejs-sculpt-dna/blob/v0.5.1/docs/VERIFIED_CAPABILITIES.md) and [machine-readable proof](https://github.com/hyeonsangjeon/threejs-sculpt-dna/blob/v0.5.1/capability-proof.json): eight claims bound to 56 repository-local evidence files.
- [Security policy](https://github.com/hyeonsangjeon/threejs-sculpt-dna/blob/v0.5.1/SECURITY.md) and [script policy](https://github.com/hyeonsangjeon/threejs-sculpt-dna/blob/v0.5.1/script-policy.json): all 40 Python executables are inventoried, purpose-scoped, and declare network access disabled.
- The read-only first-clone doctor and an isolated Copilot marketplace install were verified; the installed plugin exposed exactly the two declared skills.
- [GitHub Pages deployment](https://github.com/hyeonsangjeon/threejs-sculpt-dna/actions/runs/30566950495) passed for the immutable release commit.