### PR TITLE
Add Azure DevOps plugin to marketplace

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -128,6 +128,27 @@
       "repository": "https://github.com/github/copilot-advanced-security-plugin"
     },
     {
+      "name": "azure-devops-copilot-plugin",
+      "source": {
+        "source": "github",
+        "repo": "microsoft/azure-devops-copilot-plugin"
+      },
+      "description": "Bring Azure DevOps work-item, repository, and pull-request workflows into GitHub Copilot.",
+      "author": {
+        "name": "Microsoft",
+        "url": "https://www.microsoft.com"
+      },
+      "homepage": "https://github.com/microsoft/azure-devops-copilot-plugin",
+      "repository": "https://github.com/microsoft/azure-devops-copilot-plugin",
+      "keywords": [
+        "azure-devops",
+        "ado",
+        "work-items",
+        "pull-requests"
+      ],
+      "license": "MIT"
+    },
+    {
       "name": "fabric-skills",
       "source": {
         "source": "github",

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This marketplace also references plugins hosted in other repositories:
 
 - **[Advanced Security](https://github.com/github/copilot-advanced-security-plugin)** — Access to GitHub Advanced Security capabilities such as dependency scanning and secret scanning.
 
+- **[Azure DevOps Copilot Plugin](https://github.com/microsoft/azure-devops-copilot-plugin)** — Bring Azure DevOps work-item, repository, and pull-request workflows into GitHub Copilot.
+
 - **[Microsoft Skills for Fabric](https://github.com/microsoft/skills-for-fabric)** — `fabric-skills`, `fabric-authoring`, `fabric-consumption`, `fabric-operations`, `powerbi-authoring`. Skills and agents for Microsoft Fabric (Lakehouse, Warehouse, Power BI, Eventhouse, Eventstream, Dataflows, Spark).
 
 - **[Microsoft C++ Language Server](https://github.com/microsoft/cpp-language-server)** — Navigate and interact with your C++ code.


### PR DESCRIPTION
Register the Azure DevOps Copilot Plugin in this marketplace so users can discover and install its work item, repository, and pull request workflows.

The plugin is referenced directly from `microsoft/azure-devops-copilot-plugin` and documented with the other externally hosted plugins. Its metadata uses Azure DevOps-specific keywords only.